### PR TITLE
Use an one-liner to set up environment in scripts

### DIFF
--- a/bin/msc-env-find
+++ b/bin/msc-env-find
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -eu         # Exit when returns non-zero, Error when variable is unset.
+### NAME
+###     msc-env-find - Detect the environment to be used by my-sys-cfg
+###
+### SYNOPSIS
+###     msc-env-find [options]
+###
+### DESCRIPTION
+###     This program will find msc-env-find location to be used, 
+###     then print the corresponding environment variables.
+###
+### AUTHOR
+###     Ding-Yi Chen (definite), dingyichen@gmail.com
+###     Created in 2020-01-29 
+###
+
+##== Detection Start ==
+Installed=0
+MSC_BIN_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+## if MSC_BIN_DIR in PATH, then my-sys-cfg bin is installed
+case ":$PATH:" in
+    *:${MSC_BIN_DIR}:* )
+        MSC_LIBEXEC_DIR=/usr/libexec/my-sys-cfg
+        Installed=1
+        ;;
+    * )
+        MSC_LIBEXEC_DIR=$(realpath ${MSC_BIN_DIR}/../libexec )
+        ;;
+esac
+
+## source consts, so we can use them later in this program
+source $MSC_LIBEXEC_DIR/const.sh
+
+if [ $Installed -eq 1 ];then
+    MSC_ETC_MSC_DIR=/etc/my-sys-cfg
+else
+    MSC_ETC_MSC_DIR=$(realpath ${MSC_BIN_DIR}/../etc/my-sys-cfg )
+fi
+##== Parse Start ==
+SourceFunctionsShPrint=0
+###
+### OPTIONS
+while getopts "hf" opt; do
+    case $opt in
+###     -h: Show this help       
+        h)
+            sed -rne '/^###/ s/^###( )?//p' "$ThisScript"
+            exit $MSC_EXIT_OK
+            ;;
+###            
+###     -f: Print "source <path/to/functions.sh>"
+###         So calling script can just use "eval $(msc-env-find -f)"
+        f)
+            SourceFunctionsShPrint=1
+            ;;
+        *)
+            MscExitMsg="Option $opt"
+            exit $MSG_EXIT_INVALID_ARGUMENT
+            ;;
+    esac
+done
+shift $((OPTIND-1));
+
+for v in MSC_BIN_DIR MSC_LIBEXEC_DIR MSC_ETC_MSC_DIR; do
+    echo "export $v=$(eval echo \$$v)"
+done
+
+if [ $SourceFunctionsShPrint -eq 1 ];then
+    echo "source $MSC_LIBEXEC_DIR/const.sh"
+    echo "source $MSC_LIBEXEC_DIR/functions.sh"
+fi

--- a/bin/msc-prof-get
+++ b/bin/msc-prof-get
@@ -20,13 +20,7 @@ MSG_LOG_TAG=Statup
 MSC_LOG_PREFIX="[msc-prof-get] "
 
 ScriptDir=$(dirname $(realpath ${BASH_SOURCE[0]}))
-if [ -r /etc/my-sys-cfg/local.sh ];then
-    source /etc/my-sys-cfg/local.sh
-else
-    : ${MSC_LIBEXEC_DIR:=/usr/libexec/my-sys-cfg}
-    export MSC_LIBEXEC_DIR
-fi
-source $MSC_LIBEXEC_DIR/functions.sh
+eval $($(dirname $(realpath ${BASH_SOURCE[0]}))/msc-env-find -f)
 
 ##== Function Start ==
 match_host(){

--- a/bin/msc-router-mac
+++ b/bin/msc-router-mac
@@ -1,5 +1,5 @@
 #/bin/sh
-#set -eu
+set -eu
 ScriptDir=$(dirname $(realpath ${BASH_SOURCE[0]}))
 RouterIp=$($ScriptDir/msc-router-ip)
 if [ -z "${RouterIp}" ]; then

--- a/bin/msc-ssh-ok
+++ b/bin/msc-ssh-ok
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 Verbose=1
 while getopts "qv" opt; do
     case $opt in

--- a/bin/msc-ssl-csr-new
+++ b/bin/msc-ssl-csr-new
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu         # Exit when returns non-zero, Error when variable is unset.
 ### NAME
-###     msc-ssl-csr-new - Generate a CSR for requesting SSL Certificate 
+###     msc-ssl-csr-new - Generate a CSR for requesting SSL Certificate
 ###
 ### SYNOPSIS
 ###     msc-ss-csr-new [options] [Host.domain]
@@ -13,15 +13,9 @@ set -eu         # Exit when returns non-zero, Error when variable is unset.
 ###     Ding-Yi Chen (definite), dchen@redhat.com
 ###     Created in 2019-12-29 14:53
 ###
+
 ThisScript=$(realpath ${BASH_SOURCE[0]})
-ScriptDir=$(dirname "$ThisScript")
-if [ -r /etc/my-sys-cfg/local.sh ];then
-    source /etc/my-sys-cfg/local.sh
-else
-    : ${MSC_LIBEXEC_DIR:=/usr/libexec/my-sys-cfg}
-    export MSC_LIBEXEC_DIR
-fi
-source $MSC_LIBEXEC_DIR/functions.sh
+eval $($(dirname $ThisScript)/msc-env-find -f)
 
 ##== Function Start ==
 
@@ -34,30 +28,30 @@ Days=3650   # 10 years
 ### OPTIONS
 while getopts "hD:H:N:n" opt; do
     case $opt in
-###     -h: Show this help       
+###     -h: Show this help
         h)
             sed -rne '/^###/ s/^###( )?//p' "$ThisScript"
             exit $MSC_EXIT_OK
             ;;
-###            
+###
 ###     -D <days>: Certificate valid for this many days
 ###         Default: 3650  (10 Years)
         D)
             Days=$OPTARG
             ;;
-###            
+###
 ###     -H <host.fqdn>: FQDN of the host
 ###         Default: content of /etc/hostname
         H)
             Host=$OPTARG
             ;;
-###            
+###
 ###     -N <name>: Use as filename prefix
 ###         Default: Same as host.fqdn
          N)
             Name=$OPTARG
             ;;
-###            
+###
 ###     -n: No IP fill in SAN
 ###         Without this option, the IP resolve with "dig +short" will be used
 ###         in Subject Alternate Name (SAN). This option prevent this.
@@ -98,4 +92,4 @@ openssl req -new -newkey rsa:4096 -sha256 -nodes \
         echo "subjectAltName=$SubjectAltName")\
     -subj "/CN=$Host"
 
-# vim: set et si ts=4 sw=4: 
+# vim: set et si ts=4 sw=4:

--- a/bin/msc-xrandr-set
+++ b/bin/msc-xrandr-set
@@ -3,17 +3,10 @@
 MSG_LOG_TAG=Statup
 MSC_LOG_PREFIX="[msc-xrandr-set] "
 
-ScriptDir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+## Setup my-cfg-sys environment
+eval "$($(dirname $(realpath ${BASH_SOURCE[0]}))/msc-env-find -f)"
 
-if [ -r /etc/my-sys-cfg/local.sh ];then
-    source /etc/my-sys-cfg/local.sh
-else
-    : ${MSC_LIBEXEC_DIR:=/usr/libexec/my-sys-cfg}
-    export MSC_LIBEXEC_DIR
-fi
-source $MSC_LIBEXEC_DIR/functions.sh
-
-Prof=$($ScriptDir/msc-prof-get)
+Prof=$($MSC_BIN_DIR/msc-prof-get)
 OutputProfile=
 declare -A OutputMode
 declare -A OutputOptions

--- a/libexec/const.sh
+++ b/libexec/const.sh
@@ -1,5 +1,6 @@
 ### Usage: source const.sh
 ###     Definition of constants
+MSC_VERSION=0.6.0
 
 : ${MSC_ETC_MSC_DIR:=/etc/my-sys-cfg}
 export MSC_ETC_MSC_DIR

--- a/libexec/functions.sh
+++ b/libexec/functions.sh
@@ -117,6 +117,13 @@ msc_apply(){
 }
 
 ###
+### msc_program_print_help <cmd>
+###     Print in-line help of a program
+msc_help_print(){
+    sed -rne '/^###/ s/^###( )?//p' "$1"
+}
+
+###
 ### msc_str_contains_substr <str> <substr>
 ###     Whether the string contains substring.
 ###     Returns: 0 if <str> contains <substr>; 1 otherwise

--- a/libexec/msc-find-env.sh
+++ b/libexec/msc-find-env.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -eu         # Exit when returns non-zero, Error when variable is unset.
 ### NAME
-###     msc-prof-get - Get the profile of current system
+###     msc-install-sys-dir - Install files to system directory
 ###
 ### SYNOPSIS
-###     msc-prof-get [options]
+###     msc-install-sys-dir [options]
 ###
 ### DESCRIPTION
 ###     Echo the profile of current system.
@@ -14,13 +14,19 @@ set -eu         # Exit when returns non-zero, Error when variable is unset.
 ###
 ### AUTHOR
 ###     Ding-Yi Chen (definite), dchen@redhat.com
-###     Created in 2019-08-23 15:42:30
+###     Created in 2020-01-29 
 ###
-MSG_LOG_TAG=Statup
-MSC_LOG_PREFIX="[msc-prof-get] "
+MSG_LOG_TAG=Install
+MSC_LOG_PREFIX="[msc-install-sys-dir] "
 
-## Setup my-cfg-sys environment
-eval "$($(dirname $(realpath ${BASH_SOURCE[0]}))/msc-env-find -f)"
+ScriptDir=$(dirname $(realpath ${BASH_SOURCE[0]}))
+if [ -r /etc/my-sys-cfg/local.sh ];then
+    source /etc/my-sys-cfg/local.sh
+else
+    : ${MSC_LIBEXEC_DIR:=/usr/libexec/my-sys-cfg}
+    export MSC_LIBEXEC_DIR
+fi
+source $MSC_LIBEXEC_DIR/functions.sh
 
 ##== Function Start ==
 match_host(){


### PR DESCRIPTION
`msc-env-find` not only discover the environment, but also serve as an one-liner to set up environment and dependency in scripts.